### PR TITLE
Bug fix for the macro extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,4 @@ FodyWeavers.xsd
 !/Dependencies/setup_packages.sh
 !/Dependencies/setup_programs.sh
 /build/
+/cache/

--- a/MacroExtractor/MacroExtractor.cs
+++ b/MacroExtractor/MacroExtractor.cs
@@ -98,13 +98,12 @@ namespace MacroExtractor
                     var changeParams = macro.Parameters.Values.Where(x => !x.Name.StartsWith("?"));
                     var replacementDict = new Dictionary<string, string>();
                     foreach (var arg in changeParams)
-                        replacementDict.Add(arg.Name, $"?O{id}");
+                        replacementDict.Add(arg.Name, $"?O{id++}");
                     foreach (var arg in replacementDict.Keys)
                     {
                         var allRefs = macro.FindNames(arg);
                         foreach (var aRef in allRefs)
-                            aRef.Name = $"?O{id}";
-                        id++;
+                            aRef.Name = replacementDict[arg];
                     }
 
                     foreach (var step in actionPlan.Plan)

--- a/MetaActions.Train/Properties/launchSettings.json
+++ b/MetaActions.Train/Properties/launchSettings.json
@@ -8,7 +8,7 @@
       "distributionName": "",
       //"commandLineArgs": "MetaActions.Learn/bin/Debug/net7.0/MetaActions.Learn.dll --domains Dependencies/learning-benchmarks/*/domain.pddl --train-problems Dependencies/learning-benchmarks/*/training/easy/p0*.pddl --test-problems Dependencies/learning-benchmarks/*/training/easy/p1*.pddl --rebuild false",
       //"commandLineArgs": "MetaActions.Learn/bin/Debug/net7.0/MetaActions.Learn.dll --domains Dependencies/learning-benchmarks/*/domain.pddl --train-problems Dependencies/learning-benchmarks/*/training/easy/p01.pddl --test-problems Dependencies/learning-benchmarks/satellite/training/easy/p1*.pddl --rebuild false",
-      "commandLineArgs": "MetaActions.Train/bin/Debug/net7.0/MetaActions.Train.dll --domains Dependencies/learning-benchmarks/floortile/domain.pddl --train-problems Dependencies/learning-benchmarks/*/training/easy/p01.pddl --test-problems Dependencies/learning-benchmarks/*/testing/easy/*.pddl",
+      "commandLineArgs": "MetaActions.Train/bin/Debug/net7.0/MetaActions.Train.dll --domains Dependencies/learning-benchmarks/rovers/domain.pddl --train-problems Dependencies/learning-benchmarks/*/training/easy/p01.pddl --test-problems Dependencies/learning-benchmarks/*/testing/easy/*.pddl",
       "workingDirectory": "MetaActions.Train/../"
     }
   }

--- a/Tests/MacroExtractor.Tests/MacroExtractorTests.cs
+++ b/Tests/MacroExtractor.Tests/MacroExtractorTests.cs
@@ -34,6 +34,7 @@ namespace MacroExtractor.Tests
 
         [TestMethod]
         [DataRow("benchmarks/floortile/domain.pddl", "benchmarks/floortile/meta-1", 4)]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", 7)]
         [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4", 3)]
         public void Can_ExtractMacros_Count(string domain, string plansPath, int expectedMacroCount)
         {
@@ -55,6 +56,7 @@ namespace MacroExtractor.Tests
 
         [TestMethod]
         [DataRow("benchmarks/floortile/domain.pddl", "benchmarks/floortile/meta-1")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1")]
         [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4")]
         public void Can_ExtractMacros_UniqueMacrosOnly(string domain, string plansPath)
         {
@@ -76,6 +78,7 @@ namespace MacroExtractor.Tests
 
         [TestMethod]
         [DataRow("benchmarks/floortile/domain.pddl", "benchmarks/floortile/meta-1", "$meta_1")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "$meta_1")]
         [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4", "$meta_4")]
         public void Can_ExtractMacros_MetaAction(string domain, string plansPath, string metaName)
         {
@@ -99,7 +102,9 @@ namespace MacroExtractor.Tests
         [TestMethod]
         [DataRow("benchmarks/floortile/domain.pddl", "benchmarks/floortile/meta-1", "?0", "?1", "?1", "?2")]
         [DataRow("benchmarks/floortile/domain.pddl", "benchmarks/floortile/meta-1", "?0", "?1", "?2", "?3")]
-        [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4", "?0", "?1")]
+        [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4", "?0")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "?0", "?1", "?2", "?3", "?4", "?5")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "?0", "?1", "?2", "?3", "?4", "?5", "?6")]
         public void Can_ExtractMacros_MetaAction_Arguments(string domain, string plansPath, params string[] args)
         {
             // ARRANGE
@@ -115,15 +120,20 @@ namespace MacroExtractor.Tests
             var result = extractor.ExtractMacros(decl, plans);
 
             // ASSERT
+            Assert.IsTrue(result.Count > 0);
             var all = result.Where(x => FoundMatch(x.MetaAction.Arguments, args));
             foreach (var item in all)
+            {
+                Assert.AreEqual(item.MetaAction.Arguments.Count, args.Length);
                 for (int i = 0; i < args.Length; i++)
                     Assert.AreEqual(args[i], item.MetaAction.Arguments[i].Name);
+            }
         }
 
         [TestMethod]
         [DataRow("benchmarks/floortile/domain.pddl", "benchmarks/floortile/meta-1", "$macro_1")]
         [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4", "$macro_4")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "$macro_1")]
         public void Can_ExtractMacros_MacroAction(string domain, string plansPath, string macroName)
         {
             // ARRANGE
@@ -149,6 +159,13 @@ namespace MacroExtractor.Tests
         [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4", "?O0", "?0", "?1")]
         [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4", "?0", "?1", "?O0")]
         [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4", "?0", "?O0", "?O1", "?1")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "?0", "?1", "?2", "?3", "?4", "?5", "?O0")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "?0", "?1", "?2", "?3", "?O0", "?4", "?5", "?O1")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "?0", "?1", "?2", "?3", "?4", "?O0", "?5", "?O1")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "?0", "?1", "?2", "?3", "?4", "?O0", "?5")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "?0", "?1", "?2", "?3", "?4", "?5", "?6", "?O0")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "?0", "?1", "?2", "?3", "?4", "?5", "?O0", "?6")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1", "?0", "?1", "?2", "?3", "?O0", "?4", "?5", "?6", "?O1")]
         public void Can_ExtractMacros_MacroAction_Arguments(string domain, string plansPath, params string[] args)
         {
             // ARRANGE
@@ -164,15 +181,20 @@ namespace MacroExtractor.Tests
             var result = extractor.ExtractMacros(decl, plans);
 
             // ASSERT
+            Assert.IsTrue(result.Count > 0);
             var all = result.Where(x => FoundMatch(x.Macro.Parameters.Values, args));
-            foreach(var item in all)
+            foreach (var item in all)
+            {
+                Assert.AreEqual(item.Macro.Parameters.Values.Count, args.Length);
                 for (int i = 0; i < args.Length; i++)
                     Assert.AreEqual(args[i], item.Macro.Parameters.Values[i].Name);
+            }
         }
 
         [TestMethod]
         [DataRow("benchmarks/floortile/domain.pddl", "benchmarks/floortile/meta-1")]
         [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1")]
         public void Can_ExtractMacros_RemovedPrefixes(string domain, string plansPath)
         {
             // ARRANGE
@@ -201,6 +223,7 @@ namespace MacroExtractor.Tests
         [TestMethod]
         [DataRow("benchmarks/floortile/domain.pddl", "benchmarks/floortile/meta-1")]
         [DataRow("benchmarks/ferry/domain.pddl", "benchmarks/ferry/meta-4")]
+        [DataRow("benchmarks/rovers/domain.pddl", "benchmarks/rovers/meta-1")]
         public void Can_ExtractMacros_RemovedSufixes(string domain, string plansPath)
         {
             // ARRANGE


### PR DESCRIPTION
Noticed that i didnt put the correct IDs for the macro extractor "wild card" objects.
Also added a caching method for the initial macro extraction
closes #116 